### PR TITLE
namespace-package

### DIFF
--- a/python/petsird/__init__.py
+++ b/python/petsird/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "petsird_helpers"
+name = "petsird-helpers"
 version = "0.0.0"
 description = "Library and tools for working with Positron Emission Tomography Standardization Initiative Raw Data (PETSIRD)"
 authors = [


### PR DESCRIPTION
After moving [PETSIRD:python/petsird/helpers](https://github.com/ETSInitiative/PETSIRD/tree/main/python/petsird/helpers) to [PETSIRD_helpers:python/petsird/helpers](https://github.com/ETSInitiative/PETSIRD_helpers/tree/main/python/petsird/helpers) this will work fine:

```sh
pip install petsirf petsird-helpers
pydoc petsird.helpers
```
